### PR TITLE
Multiple run() invocations.

### DIFF
--- a/src/pyrex/bison_.pyx
+++ b/src/pyrex/bison_.pyx
@@ -202,7 +202,6 @@ cdef class ParserEngine:
 
     def generate_exception_handler(self):
         s = ''
-
         s += '          {\n'
         s += '            PyObject* obj = PyErr_Occurred();\n'
         s += '            if (obj) {\n'
@@ -466,6 +465,7 @@ cdef class ParserEngine:
         f.write('\n'.join(tmp) + '\n')
         f.close()
 
+        # TODO: WTF is this?
         # create and set up a compiler object
         if sys.platform == 'win32':
             env = distutils.ccompiler.new_compiler(verbose=parser.verbose)


### PR DESCRIPTION
This PR improves the usage of pybison by making it possible to invoke the `run()` method of a given parser multiple times.

Here is a short example:

```python
from parser.attributes import AttributeParser
# create a parser object once
parser = BisonParser()

# use run() method with different inputs
with open("foo.md", "r") as foo:
    obj = parser.run(read=foo.read)
    print(json.dumps(obj, sort_keys=True, indent=4))

# let's use another file
with open("bar.md", "r") as bar:
    obj = parser.run(read=bar.read)
    print(json.dumps(obj, sort_keys=True, indent=4))
```