### PR TITLE
fix include in calc.py

### DIFF
--- a/doc/calc.py
+++ b/doc/calc.py
@@ -107,7 +107,7 @@ class Parser(BisonParser):
     #include <string.h>
     #include "Python.h"
     #define YYSTYPE void *
-    #include "tokens.h"
+    #include "tmp.tab.h"
     extern void *py_parser;
     extern void (*py_input)(PyObject *parser, char *buf, int *result,
                             int max_size);


### PR DESCRIPTION
This change fixes compiler errors that are thrown when trying to run this example.
```bash
[...omitted warnings...]
/tmp/pybison/pybison_Parser/tmp.l:8:10: fatal error: tokens.h: No such file or directory
    8 | #include "tokens.h"
      |          ^~~~~~~~~~
compilation terminated.
```
The name of the header file has been changed in #20 but in some places there is still the old header name.

Also i wanted to ask about this code from the above mentioned #20 
![screenpr20](https://user-images.githubusercontent.com/77413867/172406444-b97d9dc7-62c1-454c-8191-43d379d11aa6.png)
Aren't the comments wrong? Shouldn't the name be `tmp.tab.h`
The code is [here](https://github.com/lukeparser/pybison/blob/df6744a00a92b8bc9924e7b745a6052b4433d7d0/src/bison/__init__.py#L104)

Lastly, always in the doc folder, the walkthrough example seem to be outdated as well because it includes `tokens.h`.

Is there something i am missing and the file `tmp.tab.h` is renamed later to `tokens.h` or was this just overlooked?