### PR TITLE
Fix doc for tokens.h file

### DIFF
--- a/doc/api/private/bison.BisonParser-class.html
+++ b/doc/api/private/bison.BisonParser-class.html
@@ -204,7 +204,7 @@ T.__new__(S, ...) -&gt; a new object with type S, a subtype of T</td></tr>
 <td><b><a href="bison.BisonParser-class.html#bisonHFile"><code>bisonHFile</code></a></b> = <span title="'tmp.tab.h'"><code><span class="variable-quote">'</span>tmp.tab.h<span class="variable-quote">'</span>                                 </code>
 </span></td></tr>
 <tr><td align="right" valign="top" width="15%"><font size="-1"><code>str</code></font></td>
-<td><b><a href="bison.BisonParser-class.html#bisonHFile1"><code>bisonHFile1</code></a></b> = <span title="'tokens.h'"><code><span class="variable-quote">'</span>tokens.h<span class="variable-quote">'</span>                                 </code>
+<td><b><a href="bison.BisonParser-class.html#bisonHFile1"><code>bisonHFile1</code></a></b> = <span title="'tmp.tab.h'"><code><span class="variable-quote">'</span>tmp.tab.h<span class="variable-quote">'</span>                                 </code>
 </span></td></tr>
 <tr><td align="right" valign="top" width="15%"><font size="-1"><code>classobj</code></font></td>
   <td><a name="defaultNodeClass"></a><b><code>defaultNodeClass</code></b> = <a href="bison.BisonNode-class.html"><code>bison.BisonNode</code></a></td></tr>
@@ -584,10 +584,10 @@ None&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbs
           <code>str</code>
 
       </dd>
-<span title="'tokens.h'">      <dt><b>Value:</b></dt>
+<span title="'tmp.tab.h'">      <dt><b>Value:</b></dt>
       <dd><table><tr><td>
 <pre class="variable">
-<span class="variable-quote">'</span>tokens.h<span class="variable-quote">'</span>                                                             </pre>
+<span class="variable-quote">'</span>tmp.tab.h<span class="variable-quote">'</span>                                                             </pre>
         </td></tr></table></dd>
 </span>    </dl>
   </dd>

--- a/doc/api/public/bison.BisonParser-class.html
+++ b/doc/api/public/bison.BisonParser-class.html
@@ -186,7 +186,7 @@ T.__new__(S, ...) -&gt; a new object with type S, a subtype of T</td></tr>
 <td><b><a href="bison.BisonParser-class.html#bisonHFile"><code>bisonHFile</code></a></b> = <span title="'tmp.tab.h'"><code><span class="variable-quote">'</span>tmp.tab.h<span class="variable-quote">'</span>                                 </code>
 </span></td></tr>
 <tr><td align="right" valign="top" width="15%"><font size="-1"><code>str</code></font></td>
-<td><b><a href="bison.BisonParser-class.html#bisonHFile1"><code>bisonHFile1</code></a></b> = <span title="'tokens.h'"><code><span class="variable-quote">'</span>tokens.h<span class="variable-quote">'</span>                                 </code>
+<td><b><a href="bison.BisonParser-class.html#bisonHFile1"><code>bisonHFile1</code></a></b> = <span title="'tmp.tab.h'"><code><span class="variable-quote">'</span>tmp.tab.h<span class="variable-quote">'</span>                                 </code>
 </span></td></tr>
 <tr><td align="right" valign="top" width="15%"><font size="-1"><code>classobj</code></font></td>
   <td><a name="defaultNodeClass"></a><b><code>defaultNodeClass</code></b> = <a href="bison.BisonNode-class.html"><code>bison.BisonNode</code></a></td></tr>
@@ -550,10 +550,10 @@ None&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbs
           <code>str</code>
 
       </dd>
-<span title="'tokens.h'">      <dt><b>Value:</b></dt>
+<span title="'tmp.tab.h'">      <dt><b>Value:</b></dt>
       <dd><table><tr><td>
 <pre class="variable">
-<span class="variable-quote">'</span>tokens.h<span class="variable-quote">'</span>                                                             </pre>
+<span class="variable-quote">'</span>tmp.tab.h<span class="variable-quote">'</span>                                                             </pre>
         </td></tr></table></dd>
 </span>    </dl>
   </dd>

--- a/doc/walkthrough.html
+++ b/doc/walkthrough.html
@@ -205,7 +205,7 @@
     #include &lt;string.h&gt;
     #include "Python.h"
     #define YYSTYPE void *
-    #include "tokens.h"
+    #include "tmp.tab.h"
     extern void *py_parser;
     extern void (*py_input)(PyObject *parser, char *buf, int *result, int max_size);
     #define returntoken(tok) yylval = PyUnicode_FromString(strdup(yytext)); return (tok);
@@ -231,11 +231,11 @@
     just give them opaque pointers, and <b>void *</b> will suffice just fine.
     
     <b><pre>
-    #include "tokens.h"</pre></b>
+    #include "tmp.tab.h"</pre></b>
     
     When PyBison first instantiates any given parser class (and auto-generates, processes,
     compiles, links the grammar/scanner files into a dynamic lib), the bison program generates
-    a header file of token definitions, which gets renamed to <b>tokens.h</b>. Your scanner
+    a header file of token definitions, which gets renamed to <b>tmp.tab.h</b>. Your scanner
     script will need this file, so the token macros will be defined and resolved to the correct
     token numbers.
     
@@ -690,7 +690,7 @@
     #include &lt;string.h&gt;
     #include "Python.h"
     #define YYSTYPE void *
-    #include "tokens.h"
+    #include "tmp.tab.h"
     extern void *py_parser;
     extern void (*py_input)(PyObject *parser, char *buf, int *result, int max_size);
     #define returntoken(tok) yylval = PyUnicode_FromString(strdup(yytext)); return (tok);
@@ -775,7 +775,7 @@
     #include &lt;string.h&gt;
     #include "Python.h"
     #define YYSTYPE void *
-    #include "tokens.h"
+    #include "tmp.tab.h"
     extern void *py_parser;
     extern void (*py_input)(PyObject *parser, char *buf, int *result, int max_size);
     #define returntoken(tok) yylval = PyUnicode_FromString(strdup(yytext)); return (tok);

--- a/src/bison/__init__.py
+++ b/src/bison/__init__.py
@@ -99,9 +99,9 @@ class BisonParser(object):
     bisonHFile = 'tmp.tab.h'
 
     # C output file from bison gets renamed to this.
-    bisonCFile1 = bisonCFile  # 'tmp.bison.c'
+    bisonCFile1 = bisonCFile  # 'tmp.tab.c'
     # Bison-generated header file gets renamed to this.
-    bisonHFile1 = bisonHFile  # 'tokens.h'
+    bisonHFile1 = bisonHFile  # 'tmp.tab.h'
 
     # flex file names
     flexFile = 'tmp.l'


### PR DESCRIPTION
This is just a short follow-up to #32.

This PR **changes all occurrences of the old-style `tokens.h` to the new naming scheme `tmp.tab.h`** for intermediate build-file outputs.