### PR TITLE
distutils deprecation with 3.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ elif sys.platform.startswith('linux'):
 elif sys.platform.startswith('darwin'):
     libs = ['dl']
     bisondynlibModule = str(Path("src") / "bison" / "c" / "bisondynlib-linux.c")
-    from distutils import sysconfig
+    import sysconfig
     v: dict = sysconfig.get_config_vars()
     v['LDSHARED'] = v['LDSHARED'].replace('-bundle', '-dynamiclib')
 


### PR DESCRIPTION
Since we _already_ use setuptools where possible, there is only one place we need to look at before 3.12 arrives.
Lucky for us, the `sysconfig` module is available since 3.2, so an easy fix!