### PR TITLE
fix examples by using api.value.type (instead of define YYSTYPE)

### DIFF
--- a/examples/C/c.py
+++ b/examples/C/c.py
@@ -746,6 +746,7 @@ class Parser(BisonParser):
     changes are detected, a new dynamic lib for the parser engine
     will be generated automatically.
     """
+    options = ["%define api.value.type {void *}"]
 
     # --------------------------------------------
     # basename of binary parser engine dynamic lib
@@ -1656,7 +1657,6 @@ void count();
 #include <stdio.h>
 #include <string.h>
 #include "Python.h"
-#define YYSTYPE void *
 #include "tmp.tab.h"
 extern void *py_parser;
 extern void (*py_input)(PyObject *parser, char *buf, int *result, int max_size);

--- a/examples/calc/calc.py
+++ b/examples/calc/calc.py
@@ -13,6 +13,8 @@ class Parser(BisonParser):
     Implements the calculator parser. Grammar rules are defined in the method
     docstrings. Scanner rules are in the 'lexscript' attribute.
     """
+    options = ["%define api.value.type {void *}"]
+
     # ----------------------------------------------------------------
     # lexer tokens - these must match those in your lex script (below)
     # ----------------------------------------------------------------
@@ -106,7 +108,6 @@ class Parser(BisonParser):
     #include <stdio.h>
     #include <string.h>
     #include "Python.h"
-    #define YYSTYPE void *
     #include "tmp.tab.h"
     extern void *py_parser;
     extern void (*py_input)(PyObject *parser, char *buf, int *result,

--- a/examples/calc1/calc1.py
+++ b/examples/calc1/calc1.py
@@ -18,6 +18,9 @@ class Parser(BisonParser):
     debugSymbols=True
     keepfiles = True
     import os
+
+    options = ["%define api.value.type {void *}"]
+
     #os.environ['LINK'] = '/debug'
     # ----------------------------------------------------------------
     # lexer tokens - these must match those in your lex script (below)
@@ -225,7 +228,6 @@ class Parser(BisonParser):
     #include <stdio.h>
     #include <string.h>
     #include "Python.h"
-    #define YYSTYPE void *
     #include "tmp.tab.h"
     extern void *py_parser;
     extern void (*py_input)(PyObject *parser, char *buf, int *result, int max_size);

--- a/examples/java/javaparser.py
+++ b/examples/java/javaparser.py
@@ -26,6 +26,7 @@ class Parser(BisonParser):
     changes are detected, a new dynamic lib for the parser engine
     will be generated automatically.
     """
+    options = ["%define api.value.type {void *}"]
 
     # -------------------------------------------------
     # Default class to use for creating new parse nodes
@@ -1978,7 +1979,6 @@ Escunichar   \\u{H}{H}{H}{H}
 #include <stdio.h>
 #include <string.h>
 #include "Python.h"
-#define YYSTYPE void *
 #include "tmp.tab.h"
 extern void *py_parser;
 extern void (*py_input)(PyObject *parser, char *buf, int *result, int max_size);

--- a/examples/json/jsonparser.py
+++ b/examples/json/jsonparser.py
@@ -10,6 +10,8 @@ class Parser(BisonParser):
     def __init__(self, **kwargs):
         self.bisonEngineLibName = self.__class__.__name__ + '_engine'
 
+        options = ["%define api.value.type {void *}"]
+
         tokens = [[x.strip() for x in y.split('=')]
                   for y in self.__doc__.split('\n')
                   if y.strip() != '']

--- a/examples/template/template.py
+++ b/examples/template/template.py
@@ -67,6 +67,9 @@ class Parser(BisonParser):
     Describe your parser here
     """
 
+    # bison options
+    options = ["%define api.value.type {void *}"]
+
     # basename of binary parser engine dynamic lib
     bisonEngineLibName = "template-engine"
 
@@ -121,7 +124,6 @@ class Parser(BisonParser):
 #include <stdio.h>
 #include <string.h>
 #include "Python.h"
-#define YYSTYPE void *
 #include "tmp.tab.h"
 //int yylineno = 0;
 int yywrap() { return(1); }


### PR DESCRIPTION
Most examples did not work properly.

This fix solves this by using the newer bison options for grammar rule return types (`%define api.value.type`) instead of using the rather low-level `#define YYSTYPE`.

Without the fix, all examples did crash with a Segmentation Fault error.

With the fix in place the following examples work again:
- [x] `C`
   parsing a bison output file succeeds & the returned AST seems to be correct.
- [x] `calc`
   prompt returns correct values. however, the `QUIT` command does not exit the code. (I will create an issue for that).
- [ ] `calc1`
   The promt works again, however the commands are not recognized by the parser.
- [x] `java`
   parsing the example file succeeds & the returned AST seems to be correct.
- [ ] `json`
   still returns a segmentation fault
- [x] `template` (adapted its code as well)

