### PR TITLE
ignore compiled subdirectory in tests/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+tests/**/compiled/
+
+
+
 .idea
 
 *.sw[a-z]


### PR DESCRIPTION
This PR ignores the `compiled` subfolders inside `./tests`.

The current test-setup is to put all intermediate files for building into a folder called `compiled`.
While we could move that to `/tmp`, I personally find it good to have the files right besides the tests for further inspection when something goes wrong.
